### PR TITLE
allow_catching_keyboard_interrupt

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_bundle/pydev_console_utils.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_bundle/pydev_console_utils.py
@@ -397,8 +397,10 @@ class BaseInterpreterInterface:
             if self.interruptable:
                 # Fix for #PyDev-500: Console interrupt can't interrupt on sleep
                 interrupt_main_thread(self.mainThread)
-
-            self.finish_exec(False)
+            # Don't assume that just because we've interrupted the main thread,
+            # it will actually finish.
+            # The KeyboardInterrupt exception may be handled by the code in question.
+            # self.finish_exec(False)
             return True
         except:
             traceback.print_exc()


### PR DESCRIPTION
https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/2

Change to pydev to ensure that we can catch and respond to `KeyboardInterrupt` exceptions in user code.

Previously pydev was assuming that after it interrupted a script, it would return immediately - and therefore supressed any further interrupt requests. This is not true if the user code catches `KeyboardInterrupt`. This change means that further interrupt requests are honored.

This is required for example in bluesky - which uses a double ctrl-c to mean "stop now" versus a single ctrl-c which means "stop at next checkpoint".

## To review

On your dev machine, the easiest way to review this PR is to patch this file in a _built_ client.

Check that the behaviour with this PR is similar between `Pydev` (in GUI), `python.exe` interactive shell, and `IPython` (e.g. `genie_python.bat`).

(Note: pydev may give a few extra `>>` prompts, these can be ignored).

Simple example:
```python
from time import sleep
for _ in range(50):
    try:
        sleep(1)
    except KeyboardInterrupt:
        print("sorry, no")
```

Bluesky example:
```python
from ibex_bluesky_core.run_engine import get_run_engine
import bluesky.plan_stubs as bps
RE = get_run_engine()
RE(bps.sleep(99))
```

Ensure other interrupt-related functionality is unchanged, e.g. a standard `time.sleep(...)` can still be interrupted etc.

## To deploy

Once this PR is merged, run `mvn clean verify` in the merged repo, then upload the resulting artefacts to `ICP_P2` so that the GUI picks them up.